### PR TITLE
Created new properties for the speed dial

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -46,8 +46,12 @@ class _MyPageState extends State<MyPage> {
 
   Widget _buildFloatingActionButton() {
     final TextStyle customStyle = TextStyle(inherit: false, color: Colors.black);
-    final icons = [
-      SpeedDialAction(child: Icon(Icons.mode_edit), label: Text('Edit any item', style: customStyle)),
+    final icons = [ 
+      SpeedDialAction(
+        //backgroundColor: Colors.green, 
+        //foregroundColor: Colors.yellow, 
+        child: Icon(Icons.mode_edit), 
+        label: Text('Edit any item', style: customStyle)),
       SpeedDialAction(child: Icon(Icons.date_range), label: Text('Choose the date', style: customStyle)),
       SpeedDialAction(child: Icon(Icons.list), label: Text('Menu', style: customStyle)),
     ];
@@ -55,11 +59,14 @@ class _MyPageState extends State<MyPage> {
     return SpeedDialFloatingActionButton(
       actions: icons,
       childOnFold: Icon(Icons.event_note, key: UniqueKey()),
+      screenColor: Colors.black.withOpacity(0.3),
       //childOnUnfold: Icon(Icons.add),
       useRotateAnimation: false,
       onAction: _onSpeedDialAction,
       controller: _controller,
       isDismissible: true,
+      //backgroundColor: Colors.yellow,
+      //foregroundColor: Colors.blue,
     );
   }
 


### PR DESCRIPTION
Sorry for the big pull request, I got carried away.

**Colors:**
I tried to wrap the speed dial in the theme widget to change the button's colors, but I was using the Speed dial inside the bottomAppBar widget rather than as a normal floating button. I found out the theme widget doesn't work in the bottomAppBar, so I created the following properties to change the buttons colors easily (just like the vanilla floatingButton):
- backgroundColor property for floating button
- foregroundColor property for floating button
- backgroundColor property for action button
- foregroundColor property for action button

**Label Position:**
On the flutter beta channel is already possible to position the floating button at the left of the screen, one just have to use the Scaffold property "floatingActionButtonLocation: FloatingActionButtonLocation.startDocked" for instance.
That will probably make its way to the stable channel, so I created a new property to the speed dial to position the label on the right of the action button when the floating button is at the left of the display. The property is optional and the Speed Dial is able to calculate the appropriated label position most of the time

**Screen Color Overlay**
Created screenColor property to change the background color when the speed dial is unfolded